### PR TITLE
Simplify the objective worfklow

### DIFF
--- a/benchmark_utils/datasets.py
+++ b/benchmark_utils/datasets.py
@@ -1,24 +1,4 @@
 import numpy as np
-from gurobipy import Model, GRB
-
-
-def compute_w_l0pb(y, X, w_true):
-    k = np.sum(w_true != 0.0)
-    n = X.shape[1]
-    M = 1.5 * np.max(np.abs(w_true))
-    model = Model()
-    w_var = model.addMVar(n, name="w", vtype="C", lb=-np.inf, ub=np.inf)
-    z_var = model.addMVar(n, name="z", vtype="B")
-    r_var = y - X @ w_var
-    model.setObjective(0.5 * (r_var @ r_var), GRB.MINIMIZE)
-    model.addConstr(w_var <= M * z_var)
-    model.addConstr(w_var >= -M * z_var)
-    model.addConstr(sum(z_var) <= k)
-    model.setParam("OutputFlag", 0)
-    model.setParam("MIPGap", 1e-8)
-    model.setParam("IntFeasTol", 1e-8)
-    model.optimize()
-    return w_var.X * (z_var.X > 0.5)
 
 
 def generate_sources(n, k, random_state=None):

--- a/benchmark_utils/metrics.py
+++ b/benchmark_utils/metrics.py
@@ -4,17 +4,6 @@ with safe_import_context() as import_ctx:
     import numpy as np
 
 
-def cv_score(X, y, w, nb_folds):
-    if nb_folds > y.size:
-        nb_folds = y.size
-    fold_size = y.size // nb_folds
-    scores = []
-    for _ in range(nb_folds):
-        ind = np.random.permutation(y.size)[:fold_size]
-        scores.append(0.5 * np.linalg.norm(y[ind] - X[ind, :] @ w, 2) ** 2)
-    return np.mean(scores)
-
-
 def snr(w_true, w):
     if np.linalg.norm(w_true - w, 2) == 0.0:
         return np.inf
@@ -43,6 +32,15 @@ def tnr(w_true, w):
     if np.sum(w_true == 0.0) == 0.0:
         return 1.0
     return np.sum((w_true == 0.0) * (w == 0.0)) / np.sum(w_true == 0.0)
+
+
+def f1score(w_true, w):
+    tp = np.sum(w_true * w)
+    fp = np.sum((w_true == 0.0) * w)
+    fn = np.sum(w_true * (w == 0.0))
+    if 2.0 * tp + fp + fn == 0.0:
+        return 1.0
+    return 2.0 * tp / (2.0 * tp + fp + fn)
 
 
 def auc(w_true, w, num_rounds=10_000):

--- a/datasets/deconvolution.py
+++ b/datasets/deconvolution.py
@@ -3,7 +3,6 @@ from benchopt import BaseDataset, safe_import_context
 with safe_import_context() as import_ctx:
     import numpy as np
     import pathlib
-    from benchmark_utils.datasets import compute_w_l0pb
 
 
 class Dataset(BaseDataset):
@@ -28,5 +27,4 @@ class Dataset(BaseDataset):
         e = np.random.randn(X.shape[0])
         e *= np.sqrt((y @ y) / (self.snr * (e @ e)))
         y += e
-        w_l0pb = compute_w_l0pb(y, X, w_true)
-        return dict(X=X, y=y, w_true=w_true, w_l0pb=w_l0pb)
+        return dict(X=X, y=y, w_true=w_true)

--- a/datasets/lattice.py
+++ b/datasets/lattice.py
@@ -30,4 +30,4 @@ class Dataset(BaseDataset):
         else:
             w_true = None
             y = f['y']
-        return dict(X=X, y=y, w_true=w_true, w_l0pb=None)
+        return dict(X=X, y=y, w_true=w_true)

--- a/datasets/libsvm.py
+++ b/datasets/libsvm.py
@@ -14,4 +14,4 @@ class Dataset(BaseDataset):
 
     def get_data(self):
         X, y = fetch_libsvm(self.dataset)
-        return dict(X=X, y=y, w_true=None, w_l0pb=None)
+        return dict(X=X, y=y, w_true=None)

--- a/datasets/meg.py
+++ b/datasets/meg.py
@@ -3,8 +3,8 @@ from benchopt import safe_import_context
 
 
 with safe_import_context() as import_ctx:
-    from sklearn.datasets import fetch_openml
     import numpy as np
+    from sklearn.datasets import fetch_openml
     from benchmark_utils.datasets import generate_sources
 
 

--- a/datasets/ode.py
+++ b/datasets/ode.py
@@ -335,4 +335,4 @@ class Dataset(BaseDataset):
         y = v.T.flatten()
         w_true = system.true_coefs.flatten()
 
-        return dict(X=X, y=y, w_true=w_true, w_l0pb=None)
+        return dict(X=X, y=y, w_true=w_true)

--- a/datasets/portfolio.py
+++ b/datasets/portfolio.py
@@ -18,4 +18,4 @@ class Dataset(BaseDataset):
         p = f["p" + self.instance]
         X = np.linalg.cholesky(self.ratio * S).T
         y = np.linalg.lstsq(X.T, (1.0 - self.ratio) * p, rcond=None)[0]
-        return dict(X=X, y=y, w_true=None, w_l0pb=None)
+        return dict(X=X, y=y, w_true=None)

--- a/datasets/simulated.py
+++ b/datasets/simulated.py
@@ -1,8 +1,5 @@
-from benchopt import BaseDataset, safe_import_context
+from benchopt import BaseDataset
 from benchopt.datasets.simulated import make_correlated_data
-
-with safe_import_context() as import_ctx:
-    from benchmark_utils.datasets import compute_w_l0pb
 
 
 class Dataset(BaseDataset):
@@ -22,5 +19,4 @@ class Dataset(BaseDataset):
             snr=self.snr,
             random_state=self.random_state,
         )
-        w_l0pb = compute_w_l0pb(y, X, w_true)
-        return dict(X=X, y=y, w_true=w_true, w_l0pb=w_l0pb)
+        return dict(X=X, y=y, w_true=w_true)

--- a/solvers/l0constraint.py
+++ b/solvers/l0constraint.py
@@ -1,17 +1,17 @@
 from benchopt import BaseSolver, safe_import_context
+from benchmark_utils.stopping_criterion import RunOnGridCriterion
 
 with safe_import_context() as import_ctx:
     import numpy as np
     from gurobipy import Model, GRB
-    from benchmark_utils.stopping_criterion import RunOnGridCriterion
-
+    
 
 class Solver(BaseSolver):
     name = "l0constraint"
     stopping_criterion = RunOnGridCriterion(grid=np.linspace(0, 0.1, 10))
 
     install_cmd = "conda"
-    requirements = ["gurobi"]
+    requirements = ["pip:gurobipy"]
 
     def set_objective(self, X, y):
         self.X = X

--- a/solvers/l0constraint.py
+++ b/solvers/l0constraint.py
@@ -11,7 +11,7 @@ class Solver(BaseSolver):
     stopping_criterion = RunOnGridCriterion(grid=np.linspace(0, 0.1, 10))
 
     install_cmd = "conda"
-    requirements = ["pip:gurobipy"]
+    requirements = ["gurobi"]
 
     def set_objective(self, X, y):
         self.X = X

--- a/solvers/l0constraint.py
+++ b/solvers/l0constraint.py
@@ -4,7 +4,7 @@ from benchmark_utils.stopping_criterion import RunOnGridCriterion
 with safe_import_context() as import_ctx:
     import numpy as np
     from gurobipy import Model, GRB
-    
+
 
 class Solver(BaseSolver):
     name = "l0constraint"


### PR DESCRIPTION
- Add f1score metric
- Remove cv_score metric: not informative since we already have the objective value
- Remove all statistics linked to w_l0pb
  --> avoid the dependency to gurobi
  --> simplify the statistics notations
  --> I think this is clearer like that if we avoid mixing the "real" ground truth and the one obtained form the L0-problem resolution 